### PR TITLE
Update documentation for video storage clarity

### DIFF
--- a/content/docs/YakShaver/recording-work-item-screenshot-app.mdx
+++ b/content/docs/YakShaver/recording-work-item-screenshot-app.mdx
@@ -14,12 +14,21 @@ If you are on Mac, here's how you can set up the inbuilt [Screenshots App](https
 ## Setting up the Screenshot App
 
 1. **⚠️ IMPORTANT:** YakShaver | Type **OFF** in the YakShaver Teams bot. This will prevent old videos from being processed.
-2. In your OneDrive Recordings' folder, create a new Folder called `ScreenshotApp`, i.e. `OneDrive\Recordings\ScreenshotApp`
-3. Screenshot App | Press `CMD + Shift + 5` to open the Screenshot App
-4. Screenshot App | Options
-   1. Save to | Select "Other Location", and choose the `ScreenshotApp` folder you created earlier
+2. **Video Storage Location:** Videos can be stored anywhere under the 'Recordings' folder, either directly or in nested folders. YakShaver will process videos from any location within the Recordings folder structure.
+
+   **Examples of valid storage locations:**
+   - **Direct storage:** `OneDrive\Recordings\` (files directly in the Recordings folder)
+   - **Nested folders:** 
+     - `OneDrive\Recordings\ScreenshotApp\`
+     - `OneDrive\Recordings\MacOS\Screenshots\`
+     - `OneDrive\Recordings\Projects\ProjectName\`
+
+3. Choose your preferred storage location within the Recordings folder (e.g., create a new folder called `ScreenshotApp` for organization)
+4. Screenshot App | Press `CMD + Shift + 5` to open the Screenshot App
+5. Screenshot App | Options
+   1. Save to | Select "Other Location", and choose your preferred location within the Recordings folder
    2. Microphone | Select the correct input
-5. YakShaver | Type **ON** in the YakShaver Teams bot.
+6. YakShaver | Type **ON** in the YakShaver Teams bot.
 
 ![](/YakShaver/Docs/Screenshot-App-Settings.png)
 **Figure: Ensure that the right folder and microphone are selected**


### PR DESCRIPTION
Update documentation to clarify flexible video storage paths under the 'Recordings' folder.

Previously, the documentation implied a rigid folder structure. This update clarifies that YakShaver processes videos from any subfolder within 'Recordings', providing users more organizational flexibility and examples.